### PR TITLE
Fix sceneDropId handling to prevent matching unintended assets

### DIFF
--- a/src/controllers/handleDropPiece.ts
+++ b/src/controllers/handleDropPiece.ts
@@ -17,7 +17,7 @@ import { DroppedAssetInterface } from "@rtsdk/topia";
 export const handleDropPiece = async (req: Request, res: Response) => {
   try {
     const credentials = req.credentials;
-    const { displayName, identityId, sceneDropId, urlSlug, visitorId } = credentials;
+    const { displayName, identityId, urlSlug, visitorId } = credentials;
     const { username } = req.body;
 
     let text = "",
@@ -27,7 +27,8 @@ export const handleDropPiece = async (req: Request, res: Response) => {
     const column = parseInt(req.params.column);
     if (isNaN(column)) throw "Column id is required.";
 
-    const { keyAsset } = await getDroppedAssetDataObject(credentials, false);
+    // Get the resolved sceneDropId from getDroppedAssetDataObject
+    const { keyAsset, sceneDropId } = await getDroppedAssetDataObject(credentials, false);
 
     let {
       columns,

--- a/src/controllers/handlePlayerSelection.ts
+++ b/src/controllers/handlePlayerSelection.ts
@@ -8,13 +8,15 @@ export const handlePlayerSelection = async (req: Request, res: Response) => {
     const playerId = req.params.player;
     const isPlayer2 = parseInt(playerId) === 2;
     const credentials = req.credentials;
-    const { profileId, sceneDropId, urlSlug, visitorId } = credentials;
+    const { profileId, urlSlug, visitorId } = credentials;
     const { username } = req.body;
 
     let text = "",
       shouldUpdateGame = true;
 
-    const { keyAsset } = await getDroppedAssetDataObject(credentials, false);
+    // Get the resolved sceneDropId from getDroppedAssetDataObject
+    // This ensures we use a valid sceneDropId even if credentials.sceneDropId is empty
+    const { keyAsset, sceneDropId } = await getDroppedAssetDataObject(credentials, false);
     const { keyAssetId, playerCount, player1, player2 } = keyAsset.dataObject as GameDataType;
 
     try {

--- a/src/utils/droppedAssets/getDroppedAssetDataObject.ts
+++ b/src/utils/droppedAssets/getDroppedAssetDataObject.ts
@@ -23,7 +23,14 @@ export const getDroppedAssetDataObject = async (credentials: Credentials, isKeyA
       }
     }
 
+    // If sceneDropId is not provided, use keyAssetId as the sceneDropId
+    // This ensures we always have a valid sceneDropId for asset queries
     if (!sceneDropId) sceneDropId = keyAssetId;
+
+    // Validate that we have a valid sceneDropId before proceeding
+    if (!sceneDropId || sceneDropId.trim() === "") {
+      throw "Unable to determine a valid sceneDropId. This is required to safely query assets.";
+    }
 
     // store keyAssetId by sceneDropId in World data object so that it can be accessed by any clickable asset
     // this supports a scene being dropped with the board already created instead of just the Reset button
@@ -41,7 +48,8 @@ export const getDroppedAssetDataObject = async (credentials: Credentials, isKeyA
 
     const wasDataObjectInitialized = await initializeDroppedAssetDataObject(keyAsset, sceneDropId);
 
-    return { keyAsset, wasDataObjectInitialized };
+    // Return the resolved sceneDropId so callers can use it for subsequent queries
+    return { keyAsset, wasDataObjectInitialized, sceneDropId };
   } catch (error) {
     return errorHandler({
       error,


### PR DESCRIPTION
All controllers now use the resolved sceneDropId from getDroppedAssetDataObject instead of directly using credentials.sceneDropId which could be empty.

- getDroppedAssetDataObject now validates and returns the resolved sceneDropId
- handleResetBoard uses resolved sceneDropId for queries and generateBoard calls
- handleDropPiece uses resolved sceneDropId for asset queries
- handlePlayerSelection uses resolved sceneDropId for asset queries

This prevents queries with empty sceneDropId from matching all assets in a world.

## Summary

##### _Summarize the changes that have been made to the platform._

<br>

## What kind of change does this PR introduce?

##### _New feature, docs update, etc._

<br>

## Current Behavior

##### _Tell us what is happening currently._

<br>

## New Behavior

##### _What new feature or update to existing feature are you introducing?_

<br>

## Does this PR introduce a breaking change?

##### _If so, please provide specifics._

<br>

## Detailed Description and Additional Information

##### _Provide a detailed description of the change or addition you are proposing._
